### PR TITLE
Cygpath utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ SYNOPSIS
 DESCRIPTION
        This utility is an opam plugin that generates a standalone MSI file.
        This file is used by Windows Installer to make available a chosen
-       executable from an Opam package throughout the entire system.
+       executable from an opam package throughout the entire system.
 
        Generated MSI indicates to system to create an installation directory
        named 'Package Version.Executable' under "Program Files" folder and to

--- a/opam-wix.opam
+++ b/opam-wix.opam
@@ -10,7 +10,7 @@ tags: ["wix" "msi" "windows" "cygwin"]
 license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/OCamlPro/opam-wix"
 bug-reports: "https://github.com/OCamlPro/opam-wix/issues"
-#available: (os = "cygwin")
+available: (os = "cygwin")
 depends: [
   "ocaml" {build & >= "4.14.0"}
   "ocamlfind" {build}
@@ -29,9 +29,9 @@ build: [
     "@runtest" {with-test}
 ]
 dev-repo: "git+https://github.com/OCamlPro/opam-wix"
-synopsis: "A tool that produces stand-alone MSI installer for Opam packages"
+synopsis: "A tool that produces stand-alone MSI installer for opam packages"
 description: """
-opam-wix is command-line tool that, generates MSI installer for Opam package and binaries in this way:
+opam-wix is command-line tool that, generates MSI installer for ospam package and binaries in this way:
 - It searches for executable file within specified package that should be installed in
 current switch.
 - It imports all required DLLs for given binary.

--- a/src/cygcheck.ml
+++ b/src/cygcheck.ml
@@ -5,21 +5,6 @@ let filter_system32 path =
       false
   | _ -> true
 
-let cygwin_from_windows_path path =
-  let remove_colon path =
-    String.(sub path 0 (length path - 1))
-  in
-  match String.split_on_char '\\' path with
-  | disk :: path ->
-    let cygwin_path =
-      "/cygdrive" ::
-      String.lowercase_ascii (remove_colon disk) ::
-      path
-    in
-    String.concat "/" cygwin_path
-  | [] -> ""
-
-
 let get_dlls path =
   let check_consistency result =
     (* if cygchecks produces less then 3 lines, it signifies an error *)
@@ -37,5 +22,5 @@ let get_dlls path =
   List.filter_map (fun dll ->
     let dll = String.trim dll in
     if filter_system32 dll
-    then Some (cygwin_from_windows_path dll |> OpamFilename.of_string)
+    then Some System.(cyg_win_path `CygAbs dll |> OpamFilename.of_string)
     else None)

--- a/src/opamWixMain.ml
+++ b/src/opamWixMain.ml
@@ -228,14 +228,14 @@ let create_bundle cli =
     OpamFilename.write OpamFilename.Op.(tmp_dir//addwxs1) content1;
     OpamFilename.write OpamFilename.Op.(tmp_dir//addwxs2) content2;
     let additional_wxs = List.map
-      (fun d -> OpamFilename.to_string d |> System.windows_from_cygwin_path "C:")
+      (fun d -> OpamFilename.to_string d |> System.cyg_win_path `WinAbs)
       OpamFilename.Op.[ tmp_dir//addwxs1; tmp_dir//addwxs2 ]
     in
     let main_path = OpamFilename.Op.(tmp_dir // (name ^ ".wxs")) in
     Wix.write_wxs (OpamFilename.to_string main_path) wxs;
     OpamConsole.formatted_msg "Compiling WiX components...\n";
     let wxs_files =
-      (OpamFilename.to_string main_path |> System.windows_from_cygwin_path "C:")
+      (OpamFilename.to_string main_path |> System.cyg_win_path `WinAbs)
       :: additional_wxs
     in
     let candle = System.{
@@ -258,11 +258,11 @@ let create_bundle cli =
       ~dst:OpamFilename.Op.(tmp_dir // addwxs2_obj);
     let wixobj_files = [
       Filename.concat (OpamFilename.Dir.to_string tmp_dir) main_obj
-        |> System.windows_from_cygwin_path "C:";
+        |> System.cyg_win_path `WinAbs;
       Filename.concat (OpamFilename.Dir.to_string tmp_dir) addwxs1_obj
-        |> System.windows_from_cygwin_path "C:";
+        |> System.cyg_win_path `WinAbs;
       Filename.concat (OpamFilename.Dir.to_string tmp_dir) addwxs2_obj
-        |> System.windows_from_cygwin_path "C:"
+        |> System.cyg_win_path `WinAbs
     ]
     in
     let light = System.{

--- a/src/opamWixMain.ml
+++ b/src/opamWixMain.ml
@@ -96,7 +96,7 @@ end
 
 let create_bundle cli =
   let create_bundle global_options conf () =
-    OpamConsole.header_msg "Initialising Opam";
+    OpamConsole.header_msg "Initialising opam";
     System.check_avalable_commands (OpamFilename.Dir.to_string conf.wix_path);
     OpamArg.apply_global_options cli global_options;
     OpamGlobalState.with_ `Lock_read @@ fun gt ->
@@ -104,7 +104,7 @@ let create_bundle cli =
     let package =
       try OpamSwitchState.find_installed_package_by_name st conf.package
       with Not_found -> OpamConsole.error_and_exit `Not_found
-      "Package %s isn't found in your current switch. Please, run %s and retry."
+      "Package %s isn't found in your current swFitch. Please, run %s and retry."
       (OpamConsole.colorise `bold (OpamPackage.Name.to_string conf.package))
       (OpamConsole.colorise `bold ("opam install " ^ (OpamPackage.Name.to_string conf.package)))
     in
@@ -283,14 +283,14 @@ let create_bundle cli =
     OpamGlobalState.drop gt
   in
   let doc =
-    "Windows MSI installer generation for Opam packages"
+    "Windows MSI installer generation for opam packages"
   in
   let man = [
     `S Manpage.s_synopsis;
     `P "$(b,opam-wix) $(i,PACKAGE) [-b $(i,NAME)|--bp $(i,PATH)] [$(i,OTHER OPTION)]… ";
     `S Manpage.s_description;
     `P "This utility is an opam plugin that generates a standalone MSI file. This file is \
-    used by Windows Installer to make available a chosen executable from an Opam package \
+    used by Windows Installer to make available a chosen executable from an opam package \
     throughout the entire system.";
     `P "Generated MSI indicates to system to create an installation directory named \
     '$(b,Package Version.Executable)' under \"Program Files\" folder and to store there \

--- a/src/system.ml
+++ b/src/system.ml
@@ -14,9 +14,12 @@ type light = {
   light_out : string
 }
 
+type cygpath_out = [ `Win | `WinAbs | `Cyg | `CygAbs ]
+
 type _ command =
   | Which : string command
-  | Cygcheck: string command
+  | Cygcheck : string command
+  | Cygpath : (cygpath_out * string) command
   | Uuidgen : uuid_mode command
   | Candle : candle command
   | Light : light command
@@ -26,9 +29,17 @@ exception System_error of string
 let call_inner : type a. a command -> a -> string * string list =
   fun command args -> match command, args with
   | Which, (path : string) ->
-    "which", [path]
+    "which", [ path ]
   | Cygcheck, path ->
     "cygcheck", [ path ]
+  | Cygpath, (out, path) ->
+    let opts = match out with
+      | `Win -> "-w"
+      | `WinAbs -> "-wa"
+      | `Cyg -> "-u"
+      | `CygAbs -> "-ua"
+    in
+    "cygpath", [ opts; path ]
   | Uuidgen, Rand ->
     "uuidgen", []
   | Uuidgen, Exec (p,e,v) ->
@@ -88,12 +99,13 @@ let call_list : type a. (a command * a) list -> unit =
 let check_avalable_commands wix_path =
   call_list [
     Which, "cygcheck";
+    Which, "cygpath";
     Which, "uuidgen";
     Which, Filename.concat wix_path "candle.exe";
     Which, Filename.concat wix_path "light.exe";
   ]
 
-let windows_from_cygwin_path cygwin_disk path =
+(* let windows_from_cygwin_path cygwin_disk path =
   match String.split_on_char '/' (String.trim path) with
   | ""::"cygdrive" :: disk :: rest ->
     let disk = String.uppercase_ascii disk ^ ":" in
@@ -106,3 +118,5 @@ let windows_from_cygwin_path cygwin_disk path =
     (match String.split_on_char '/' path with
     | ""::rest | rest -> String.concat "\\" (cygwin_disk :: "cygwin64" :: rest))
 
+ *)
+let cyg_win_path out path = call Cygpath (out,path) |> List.hd |> String.trim

--- a/src/system.mli
+++ b/src/system.mli
@@ -24,10 +24,19 @@ type light = {
   light_out : string
 }
 
+(** Expected output path type *)
+type cygpath_out = [
+  | `Win (** Path Windows *)
+  | `WinAbs (** Absolute Path Windows *)
+  | `Cyg (** Path Cygwin *)
+  | `CygAbs (** Absolute Path Cygwin *)
+  ]
+
 (** External commands that could be called and handled by {b opam-wix}. *)
 type _ command =
   | Which : string command  (** {b which} command, to check programs availability *)
   | Cygcheck: string command   (** {b cygcheck} command to get binaries' DLLs paths *)
+  | Cygpath : (cygpath_out * string) command (** {b cygpath} command to translate path between cygwin and windows and vice-versa *)
   | Uuidgen : uuid_mode command  (** {b uuidgen} command to create a new UUID value, based on seed. *)
   | Candle : candle command  (** {b candle.exe} command as a part of WiX toolset to compile Wix source files. *)
   | Light : light command  (** {b light.exe} command as a part of WiX toolset to link all compiled Wix source files in MSI. *)
@@ -45,6 +54,5 @@ val call_list : ('a command * 'a) list -> unit
 (** Checks if all handled commands are available system-widely. *)
 val check_avalable_commands : string -> unit
 
-(** [windows_from_cygwin_path cygwin_disk path] translates cygwin path to windows path.
-    [cygwin_disk] indicates disk name ("C:", "D:") where cygwin root is stored in {i cygwin64} folder*)
-val windows_from_cygwin_path : string -> string -> string
+(** Performs path translations between Windows and Cygwin. See [System.cygpath_out] for more details. *)
+val cyg_win_path : cygpath_out -> string -> string


### PR DESCRIPTION
This PR modify translation between Cygwin and Windows path. Now it uses output of system program `cygpath` with predefined options.