### PR TITLE
Update current WiX backend from Wix 3.11 to Wix 6.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,9 +34,8 @@ jobs:
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
-      - run: opam install . --deps-only
-      - run: opam exec -- dune build @install
       - run: opam install . --deps-only -t
+      - run: opam exec -- dune build @install
       - run: opam exec -- dune runtest
       - run: opam config report
       - run: opam install .

--- a/data/wix/CustomInstallDir.wxs
+++ b/data/wix/CustomInstallDir.wxs
@@ -1,13 +1,39 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <?foreach WIXUIARCH in X86;X64;A64 ?>
     <Fragment>
-        <UI Id="Custom_InstallDir">
+        <UI Id="Custom_InstallDir_$(WIXUIARCH)">
+            <Publish Dialog="BrowseDlg" Control="OK" Event="CheckTargetPath" Value="[WIXUI_INSTALLDIR]" Order="1" />
+
+            <Publish Dialog="InstallDirAndOptionalShortcutDlg" Control="Next" Event="CheckTargetPath" Value="[WIXUI_INSTALLDIR]" Order="1" />
+            <Publish Dialog="InstallDirAndOptionalShortcutDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="4" />
+        </UI>
+
+        <UIRef Id="Custom_InstallDir" />
+    </Fragment>
+    <?endforeach?>
+
+    <?foreach WIXUIARCH in X86;X64;A64 ?>
+    <Fragment>
+        <UI Id="Custom_InstallDir_ExtendedPathValidation_$(WIXUIARCH)">
+            <Publish Dialog="BrowseDlg" Control="OK" Event="DoAction" Value="WixUIValidatePath_$(WIXUIARCH)" Order="1" />
+            <Publish Dialog="BrowseDlg" Control="OK" Event="SpawnDialog" Value="InvalidDirDlg" Order="2" Condition="WIXUI_INSTALLDIR_VALID&lt;&gt;&quot;1&quot;" />
+
+            <Publish Dialog="InstallDirAndOptionalShortcutDlg" Control="Next" Event="DoAction" Value="WixUIValidatePath_$(WIXUIARCH)" Order="1" />
+            <Publish Dialog="InstallDirAndOptionalShortcutDlg" Control="Next" Event="SpawnDialog" Value="InvalidDirDlg" Order="2" Condition="WIXUI_INSTALLDIR_VALID&lt;&gt;&quot;1&quot;" />
+            <Publish Dialog="InstallDirAndOptionalShortcutDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="4" Condition="WIXUI_INSTALLDIR_VALID=&quot;1&quot;" />
+        </UI>
+
+        <UIRef Id="Custom_InstallDir" />
+    </Fragment>
+    <?endforeach?>
+
+    <Fragment>
+        <UI Id="file Custom_InstallDir">
             <TextStyle Id="WixUI_Font_Normal" FaceName="Tahoma" Size="8" />
             <TextStyle Id="WixUI_Font_Bigger" FaceName="Tahoma" Size="12" />
             <TextStyle Id="WixUI_Font_Title" FaceName="Tahoma" Size="9" Bold="yes" />
 
             <Property Id="DefaultUIFont" Value="WixUI_Font_Normal" />
-            <Property Id="WixUI_Mode" Value="InstallDir" />
 
             <DialogRef Id="BrowseDlg" />
             <DialogRef Id="DiskCostDlg" />
@@ -19,32 +45,29 @@
             <DialogRef Id="ProgressDlg" />
             <DialogRef Id="ResumeDlg" />
             <DialogRef Id="UserExit" />
-            
-            <Publish Dialog="BrowseDlg" Control="OK" Event="DoAction" Value="WixUIValidatePath" Order="3">1</Publish>
-            <Publish Dialog="BrowseDlg" Control="OK" Event="SpawnDialog" Value="InvalidDirDlg" Order="4"><![CDATA[NOT WIXUI_DONTVALIDATEPATH AND WIXUI_INSTALLDIR_VALID<>"1"]]></Publish>
 
-            <Publish Dialog="ExitDialog" Control="Finish" Event="EndDialog" Value="Return" Order="999">1</Publish>
+            <Publish Dialog="ExitDialog" Control="Finish" Event="EndDialog" Value="Return" Order="999" />
 
-            <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="InstallDirAndOptionalShortcutDlg">NOT Installed</Publish>
-            <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg">Installed AND PATCH</Publish>
+            <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="InstallDirAndOptionalShortcutDlg" Condition="NOT Installed" />
+            <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Condition="Installed AND PATCH" />
 
-            <Publish Dialog="InstallDirAndOptionalShortcutDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>
-            <Publish Dialog="InstallDirAndOptionalShortcutDlg" Control="Next" Event="SetTargetPath" Value="[WIXUI_INSTALLDIR]" Order="1">1</Publish>
-            <Publish Dialog="InstallDirAndOptionalShortcutDlg" Control="Next" Event="DoAction" Value="WixUIValidatePath" Order="2">NOT WIXUI_DONTVALIDATEPATH</Publish>
-            <Publish Dialog="InstallDirAndOptionalShortcutDlg" Control="Next" Event="SpawnDialog" Value="InvalidDirDlg" Order="3"><![CDATA[NOT WIXUI_DONTVALIDATEPATH AND WIXUI_INSTALLDIR_VALID<>"1"]]></Publish>
-            <Publish Dialog="InstallDirAndOptionalShortcutDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="4">WIXUI_DONTVALIDATEPATH OR WIXUI_INSTALLDIR_VALID="1"</Publish>
-            <Publish Dialog="InstallDirAndOptionalShortcutDlg" Control="ChangeFolder" Property="_BrowseProperty" Value="[WIXUI_INSTALLDIR]" Order="1">1</Publish>
-            <Publish Dialog="InstallDirAndOptionalShortcutDlg" Control="ChangeFolder" Event="SpawnDialog" Value="BrowseDlg" Order="2">1</Publish>
-            
-            <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="InstallDirAndOptionalShortcutDlg" Order="1">NOT Installed</Publish>
-            <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="MaintenanceTypeDlg" Order="2">Installed AND NOT PATCH</Publish>
-            <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="2">Installed AND PATCH</Publish>
+            <Publish Dialog="InstallDirAndOptionalShortcutDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" />
+            <Publish Dialog="InstallDirAndOptionalShortcutDlg" Control="Next" Event="SetTargetPath" Value="[WIXUI_INSTALLDIR]" Order="3" />
+            <Publish Dialog="InstallDirAndOptionalShortcutDlg" Control="ChangeFolder" Property="_BrowseProperty" Value="[WIXUI_INSTALLDIR]" Order="1" />
+            <Publish Dialog="InstallDirAndOptionalShortcutDlg" Control="ChangeFolder" Event="SpawnDialog" Value="BrowseDlg" Order="2" />
 
-            <Publish Dialog="MaintenanceWelcomeDlg" Control="Next" Event="NewDialog" Value="MaintenanceTypeDlg">1</Publish>
+            <Publish Dialog="BrowseDlg" Control="OK" Event="SetTargetPath" Value="[_BrowseProperty]" Order="3" />
+            <Publish Dialog="BrowseDlg" Control="OK" Event="EndDialog" Value="Return" Order="4" />
 
-            <Publish Dialog="MaintenanceTypeDlg" Control="RepairButton" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
-            <Publish Dialog="MaintenanceTypeDlg" Control="RemoveButton" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
-            <Publish Dialog="MaintenanceTypeDlg" Control="Back" Event="NewDialog" Value="MaintenanceWelcomeDlg">1</Publish>
+            <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="InstallDirAndOptionalShortcutDlg" Order="1" Condition="NOT Installed" />
+            <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="MaintenanceTypeDlg" Order="2" Condition="Installed AND NOT PATCH" />
+            <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="2" Condition="Installed AND PATCH" />
+
+            <Publish Dialog="MaintenanceWelcomeDlg" Control="Next" Event="NewDialog" Value="MaintenanceTypeDlg" />
+
+            <Publish Dialog="MaintenanceTypeDlg" Control="RepairButton" Event="NewDialog" Value="VerifyReadyDlg" />
+            <Publish Dialog="MaintenanceTypeDlg" Control="RemoveButton" Event="NewDialog" Value="VerifyReadyDlg" />
+            <Publish Dialog="MaintenanceTypeDlg" Control="Back" Event="NewDialog" Value="MaintenanceWelcomeDlg" />
 
             <Property Id="ARPNOMODIFY" Value="1" />
         </UI>

--- a/data/wix/CustomInstallDirDlg.wxs
+++ b/data/wix/CustomInstallDirDlg.wxs
@@ -1,32 +1,21 @@
-<?xml version="1.0" encoding="UTF-8"?>
-
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
     <Fragment>
         <UI>
             <Dialog Id="InstallDirAndOptionalShortcutDlg" Width="370" Height="270" Title="!(loc.InstallDirDlg_Title)">
-		        <Control Id="DesktopShortcutCheckbox" Type="CheckBox"
-                 X="20" Y="140" Width="200" Height="17"
-                 Property="INSTALLSHORTCUTDESKTOP" CheckBoxValue="1"
-                 Text="Do you want to create a desktop shortcut?" />
-                <Control Id="StartMenuShortcutCheckbox" Type="CheckBox"
-                 X="20" Y="160" Width="200" Height="17"
-                 Property="INSTALLSHORTCUTSTARTMENU" CheckBoxValue="1"
-                 Text="Do you want to create a start menu shortcut?" />
-                <Control Id="AddToPathCheckbox" Type="CheckBox"
-                 X="20" Y="180" Width="200" Height="17"
-                 Property="ADDTOPATH" CheckBoxValue="0"
-                 Text="Do you want add executable to your PATH (usefull for applications without GUI)?" />
+                <Control Id="DesktopShortcutCheckbox" Type="CheckBox" X="20" Y="140" Width="200" Height="17" Property="INSTALLSHORTCUTDESKTOP" CheckBoxValue="1" Text="Do you want to create a desktop shortcut?" />
+                <Control Id="StartMenuShortcutCheckbox" Type="CheckBox" X="20" Y="160" Width="200" Height="17" Property="INSTALLSHORTCUTSTARTMENU" CheckBoxValue="1" Text="Do you want to create a start menu shortcut?" />
+                <Control Id="AddToPathCheckbox" Type="CheckBox" X="20" Y="180" Width="200" Height="17" Property="ADDTOPATH" CheckBoxValue="0" Text="Do you want add executable to your PATH (usefull for applications without GUI)?" />
                 <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="!(loc.WixUINext)" />
                 <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="!(loc.WixUIBack)" />
                 <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="!(loc.WixUICancel)">
-                    <Publish Event="SpawnDialog" Value="CancelDlg">1</Publish>
+                    <Publish Event="SpawnDialog" Value="CancelDlg" />
                 </Control>
 
                 <Control Id="Description" Type="Text" X="25" Y="23" Width="280" Height="15" Transparent="yes" NoPrefix="yes" Text="Click Next to install." />
                 <Control Id="Title" Type="Text" X="15" Y="6" Width="200" Height="15" Transparent="yes" NoPrefix="yes" Text="!(loc.InstallDirDlgTitle)" />
                 <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="!(loc.InstallDirDlgBannerBitmap)" />
-                <Control Id="BannerLine" Type="Line" X="0" Y="44" Width="370" Height="0" />
-                <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="370" Height="0" />
+                <Control Id="BannerLine" Type="Line" X="0" Y="44" Width="373" Height="0" />
+                <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="373" Height="0" />
 
                 <Control Id="FolderLabel" Type="Text" X="20" Y="60" Width="290" Height="30" NoPrefix="yes" Text="!(loc.InstallDirDlgFolderLabel)" />
                 <Control Id="Folder" Type="PathEdit" X="20" Y="100" Width="320" Height="18" Property="WIXUI_INSTALLDIR" Indirect="yes" />

--- a/src/opam-wix_cli/args.ml
+++ b/src/opam-wix_cli/args.ml
@@ -71,9 +71,12 @@ let output_dir =
       ~doc:"The output directory where bundle will be stored"
 
 let wix_path =
-  let prefix = if Sys.cygwin then "/cygdrive" else "" in
+  (* FIXME: that won't work when using a MinGW ocaml compiler under a Cygwin env... *)
+  (* NOTE1: we could retrieve this using the WIX6 environment variable *)
+  (* NOTE2: or we could rely in wix.exe to be in the PATH (the installer sets it) *)
+  let prefix = if Sys.cygwin || true then "/cygdrive" else "" in
   value
-  & opt string (prefix ^ "/c/Program Files (x86)/WiX Toolset v3.11/bin")
+  & opt string (prefix ^ "/c/Program Files/WiX Toolset v6.0/bin")
   & info [ "wix-path" ] ~docv:"DIR"
       ~doc:
         "The path where WIX tools are stored. The path should be full and \

--- a/src/opam-wix_lib/system.mli
+++ b/src/opam-wix_lib/system.mli
@@ -17,40 +17,13 @@ type uuid_mode =
   | Rand (** Random seed *)
   | Exec of string * string * string option (** Seed based on metadata information about package, its version and name of binary. *)
 
-(** Way to define in/output files for {i candle} *)
-type candle_files =
-  | One of string * string (** Input + output *)
-  | Many of string list (** Inputs *)
-
-(** Configuration options for {i candle} command as a part of WiX tools. Consists of the path to
-    WiX toolset binaries, input and output files for {i candle} as well as a list of
-    variable declarations. *)
-type candle = {
-  candle_wix_path : string;
-  candle_files : candle_files;
-  candle_defines : string list;
-}
-
-(** Configuration options for {i light} command as a part of WiX tools. Consists of the path to
+(** Configuration options for {i wix} command as a part of WiX tools. Consists of the path to
     WiX toolset binaries, input files, extensions to be used and output file path. *)
-type light = {
-  light_wix_path : string;
-  light_files : string list;
-  light_exts : string list;
-  light_out : string
-}
-
-(** Configuration options for {i heat} command as a part of WiX tools, that generates wxs file
-    for given directory structure. Consists of the path to WiX toolset binaries, directory path,
-    output filname, component group that could be used in main file to reference a generated feature,
-    reference to a directory tag in the main wxs file and variable used to rely file with the main wxs. *)
-type heat = {
-  heat_wix_path : string;
-  heat_dir : string;
-  heat_out : string;
-  heat_component_group : string;
-  heat_directory_ref : string;
-  heat_var : string
+type wix = {
+  wix_wix_path : string;
+  wix_files : string list;
+  wix_exts : string list;
+  wix_out : string
 }
 
 (** makeself script arguments *)
@@ -76,9 +49,7 @@ type _ command =
   | Ldd : string command (** {b ldd} command to get binaries .so paths *)
   | Cygpath : (cygpath_out * string) command (** {b cygpath} command to translate path between cygwin and windows and vice-versa *)
   | Uuidgen : uuid_mode command  (** {b uuidgen} command to create a new UUID value, based on seed. *)
-  | Candle : candle command  (** {b candle.exe} command as a part of WiX toolset to compile Wix source files. *)
-  | Light : light command  (** {b light.exe} command as a part of WiX toolset to link all compiled Wix source files in MSI. *)
-  | Heat : heat command  (** {b heat.exe} command as a part of WiX toolset to generate WiX source for specified directory. *)
+  | Wix : wix command
   | Makeself : makeself command (** {b makeself.sh} command to generate linux installer. *)
   | Chmod : (int * OpamFilename.t) command
 

--- a/src/opam-wix_lib/wix.mli
+++ b/src/opam-wix_lib/wix.mli
@@ -64,7 +64,7 @@ type info = {
   wix_banner_bmp_file : string;
 
   (* Embedded directories information (reference another wxs file) *)
-  wix_embedded_dirs : (string * component_group * directory_ref) list;
+  wix_embedded_dirs : (string (* name *) * component_group * directory_ref * string (* source *)) list;
 
   (* Embedded files *)
   wix_embedded_files : string list;

--- a/src/opam-wix_lib/wix_backend.ml
+++ b/src/opam-wix_lib/wix_backend.ml
@@ -10,7 +10,6 @@
 
 open Types
 
-
 let create_bundle conf (desc : Installer_config.t) ~tmp_dir =
   let wix_path = System.normalize_path conf.conf_wix_path in
   System.check_available_commands wix_path;
@@ -19,138 +18,69 @@ let create_bundle conf (desc : Installer_config.t) ~tmp_dir =
     String.capitalize_ascii basename ^ "CG"
   in
   let dir_ref basename = basename ^ "_REF" in
-  let info =
-    {
-      Wix.wix_path =
-        Filename.basename @@ OpamFilename.Dir.to_string desc.package_dir ;
+  let info = Wix.{
+      wix_path = (*Filename.basename @@*) OpamFilename.Dir.to_string desc.package_dir;
       wix_name = desc.package_name;
-      wix_version = desc.package_version ;
-      wix_description = desc.package_description ;
-      wix_manufacturer = desc.package_manufacturer ;
-      wix_guid = conf.conf_package_guid ;
-      wix_tags = desc.package_tags ;
-      wix_exec_file = desc.package_exec_file ;
-      wix_dlls = desc.package_dlls ;
-      wix_icon_file = desc.package_icon_file ;
-      wix_dlg_bmp_file = desc.package_dlg_bmp_file ;
-      wix_banner_bmp_file = desc.package_banner_bmp_file ;
-      wix_environment = desc.package_environment ;
+      wix_version = desc.package_version;
+      wix_description = desc.package_description;
+      wix_manufacturer = desc.package_manufacturer;
+      wix_guid = conf.conf_package_guid;
+      wix_tags = desc.package_tags;
+      wix_exec_file = desc.package_exec_file;
+      wix_dlls = desc.package_dlls;
+      wix_icon_file = desc.package_icon_file;
+      wix_dlg_bmp_file = desc.package_dlg_bmp_file;
+      wix_banner_bmp_file = desc.package_banner_bmp_file;
+      wix_environment = desc.package_environment;
       wix_embedded_dirs =
-        List.map (fun base ->
-            base, component_group base, dir_ref base)
-          ((List.map (fun (b,_)-> OpamFilename.Base.to_string b)
-              desc.package_embedded_dirs)
-           @ desc.package_additional_embedded_name ) ;
-      wix_embedded_files =
-        List.map (fun (base,_) ->
-            OpamFilename.Base.to_string base)
-          desc.package_embedded_files ;
-    } in
-  let wix_path = System.normalize_path conf.conf_wix_path in
-  System.call_list @@
-    List.map (fun (basename, dirname) ->
-        let basename = OpamFilename.Base.to_string basename in
-        let heat = System.{
-              heat_wix_path = wix_path;
-              heat_dir = OpamFilename.Dir.to_string dirname
-                         |> System.cyg_win_path `WinAbs;
-              heat_out = Filename.concat
-                           (OpamFilename.Dir.to_string tmp_dir)
-                           basename ^ ".wxs"
-                         |> System.cyg_win_path `WinAbs;
-              heat_component_group = component_group basename;
-              heat_directory_ref = dir_ref basename;
-              heat_var = Format.sprintf "var.%sDir" basename
-                   } in
-        System.Heat, heat
-      ) (desc.package_embedded_dirs @
-           List.map (fun dir ->
-               OpamFilename.basename_dir dir,dir)
+        List.map (fun (base, dir) ->
+            (* FIXME: do we need absolute dir ? *)
+            let base = OpamFilename.Base.to_string base in
+            base, component_group base, dir_ref base, OpamFilename.Dir.to_string dir)
+          (desc.package_embedded_dirs @
+           List.map2 (fun base dir -> OpamFilename.Base.of_string base, dir)
+             desc.package_additional_embedded_name
              desc.package_additional_embedded_dir);
+      wix_embedded_files =
+        List.map (fun (base, _) ->
+            OpamFilename.Base.to_string base)
+          desc.package_embedded_files;
+    }
+  in
   let wxs = Wix.main_wxs info in
   let name = Filename.chop_extension desc.package_exec_file in
-  let (addwxs1,content1) = Data.WIX.custom_install_dir in
+  let (addwxs1, content1) = Data.WIX.custom_install_dir in
   OpamFilename.write OpamFilename.Op.(tmp_dir//addwxs1) content1;
-  let (addwxs2,content2) = Data.WIX.custom_install_dir_dlg in
+  let (addwxs2, content2) = Data.WIX.custom_install_dir_dlg in
   OpamFilename.write OpamFilename.Op.(tmp_dir//addwxs2) content2;
   let additional_wxs =
-    List.map
-      (fun d ->
+    List.map (fun d ->
         OpamFilename.to_string d |> System.cyg_win_path `WinAbs)
       OpamFilename.Op.[ tmp_dir//addwxs1; tmp_dir//addwxs2 ]
   in
   let main_path = OpamFilename.Op.(tmp_dir // (name ^ ".wxs")) in
+  OpamConsole.formatted_msg "Preparing main WiX file...\n";
   Wix.write_wxs (OpamFilename.to_string main_path) wxs;
-  OpamConsole.formatted_msg "Compiling WiX components...\n";
-  let embedded_dirs = (List.map (fun (b,_) ->
-                           OpamFilename.Base.to_string b)
-                         desc.package_embedded_dirs)
-                      @ desc.package_additional_embedded_name
-  in
-  System.call_list @@
-    List.map (fun basename ->
-        let candle_defines = [ Format.sprintf "%sDir=%s\\%s"
-                                 basename
-                                 desc.package_fullname basename ]
-        in
-        let prefix = Filename.concat (OpamFilename.Dir.to_string tmp_dir) basename in
-        let candle = System.{
-              candle_wix_path = wix_path;
-              candle_files = One (prefix ^ ".wxs" |> cyg_win_path `WinAbs,
-                                  prefix ^ ".wixobj" |> cyg_win_path `WinAbs);
-              candle_defines
-                     } in
-        System.Candle, candle
-      ) embedded_dirs ;
   let wxs_files =
     (OpamFilename.to_string main_path |> System.cyg_win_path `WinAbs)
     :: additional_wxs
   in
-  let candle = {
-      System.candle_wix_path = wix_path;
-      candle_files = System.Many wxs_files;
-      candle_defines = []
-    } in
-  System.call_unit System.Candle candle;
-  if conf.conf_keep_wxs
-  then begin
-      List.iter (fun file ->
-          OpamFilename.copy_in (OpamFilename.of_string file)
-          @@ OpamFilename.cwd ()) (* we are altering current dir !! *)
-        wxs_files
-    end;
-  let main_obj = name ^ ".wixobj" in
-  let addwxs1_obj = Filename.chop_extension addwxs1 ^ ".wixobj" in
-  let addwxs2_obj = Filename.chop_extension addwxs2 ^ ".wixobj" in
-  OpamFilename.move ~src:(OpamFilename.of_string main_obj)
-    ~dst:OpamFilename.Op.(tmp_dir // main_obj);
-  OpamFilename.move ~src:(OpamFilename.of_string addwxs1_obj)
-    ~dst:OpamFilename.Op.(tmp_dir // addwxs1_obj);
-  OpamFilename.move ~src:(OpamFilename.of_string addwxs2_obj)
-    ~dst:OpamFilename.Op.(tmp_dir // addwxs2_obj);
-  let wixobj_files = [
-      Filename.concat (OpamFilename.Dir.to_string tmp_dir) main_obj
-      |> System.cyg_win_path `WinAbs;
-      Filename.concat (OpamFilename.Dir.to_string tmp_dir) addwxs1_obj
-      |> System.cyg_win_path `WinAbs;
-      Filename.concat (OpamFilename.Dir.to_string tmp_dir) addwxs2_obj
-      |> System.cyg_win_path `WinAbs;
-    ] @ List.map (fun base ->
-            Filename.concat (OpamFilename.Dir.to_string tmp_dir)
-              base ^ ".wixobj"
-            |> System.cyg_win_path `WinAbs ) embedded_dirs
-  in
-  let light = System.{
-        light_wix_path = wix_path;
-        light_files = wixobj_files;
-        light_exts = ["WixUIExtension"; "WixUtilExtension"];
-        light_out = (name ^ ".msi")
-              }
+  if conf.conf_keep_wxs then
+    List.iter (fun file ->
+        OpamFilename.copy_in (OpamFilename.of_string file)
+        @@ OpamFilename.cwd ()) (* we are altering current dir !! *)
+      wxs_files;
+  let wix = System.{
+      wix_wix_path = wix_path;
+      wix_files = wxs_files;
+      wix_exts = ["WixToolset.UI.wixext"; "WixToolset.Util.wixext"];
+      wix_out = (name ^ ".msi")
+    }
   in
   OpamConsole.formatted_msg "Producing final msi...\n";
-  System.call_unit System.Light light;
+  System.call_unit System.Wix wix;
   OpamFilename.remove (OpamFilename.of_string (name ^ ".wixpdb"));
   OpamFilename.move
     ~src:(OpamFilename.of_string (name ^ ".msi"))
     ~dst:OpamFilename.Op.(conf.conf_output_dir // (name ^ ".msi"));
-  OpamConsole.formatted_msg "Done.\n";
+  OpamConsole.formatted_msg "Done.\n"


### PR DESCRIPTION
This updates the current WiX backend to WiX 6.0.
This allows for a simpler workflow, fewer binaries to call (just one !) and fewer intermediate files (also juste one !).
Pushing a bit further, we could even remove the need for the uuidgen tool (we'd need to ask the user for a unique "package id", typically of the form "Company.ProductName" (which we might as well generate ourselves since we are already asking this info).

P.S: I don't like how the existing/current WiX backend names the package